### PR TITLE
Fix inconsistency with libc attribute decoration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ bitflags! {
 
 /// 'libc::epoll_event' equivalent.
 #[repr(C)]
-#[repr(packed)]
+#[cfg_attr(target_arch = "x86_64", repr(packed))]
 #[derive(Clone, Copy)]
 pub struct Event {
     pub events: u32,


### PR DESCRIPTION
Decorating the `Event` structure with the "packed" attribute,regardless of the platform, is incorrect since libc decorates the`libc::epoll_event` only for x86_64 platforms. As a consequence, on other architectures the size of the `Event` structure is different than that of the `libc::epoll_event` which is a trigger for inconsistent behavior.
See `__EPOLL_PACKED` inside [glibc source](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sys/epoll.h) which is defined to `__attribute__ ((__packed__))` only for x86_64 platforms.
