### PR TITLE
Add wrapper for libc::close to close the epoll fd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,12 @@ pub fn wait(epfd: RawFd,
     Ok(num_events)
 }
 
+/// Safe wrapper for `libc::close`
+pub fn close(epfd: RawFd) -> io::Result<()> {
+    cvt(unsafe { libc::close(epfd) })?;
+    Ok(())
+}
+
 fn cvt(result: libc::c_int) -> io::Result<libc::c_int> {
     if result < 0 { Err(Error::last_os_error()) } else { Ok(result) }
 }


### PR DESCRIPTION
The library should not require me to use unsafe code in order to close the created epoll fd.