### PR TITLE
pass capacity as `max_events` to `epoll_wait`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub fn wait(epfd: RawFd, timeout: i32, buf: &mut [Event]) -> io::Result<usize> {
         cvt(libc::epoll_wait(
             epfd,
             buf.as_mut_ptr() as *mut libc::epoll_event,
-            buf.len() as i32,
+            buf.capacity() as i32,
             timeout,
         ))? as usize
     };


### PR DESCRIPTION
> Up to maxevents are returned by epoll_wait(). The maxevents argument must be greater than zero.

Passing the length here doesn't really make sense. Passing `Vec::with_capacity(1024)` currently causes in invalid argument exception because the length is still 0.